### PR TITLE
get-gsheetdata empty strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # UMN-Google
 
+## Update '1.2.9'
+
+Modify Get-GSheetData to set all empty properties of the returned object to an empty string instead of $null.
+Previously any empty value in a row after the last value would be $null but empty values before the last value would be an empty string.
+This makes the behavior consistent so empty values are always empty strings.
+
 ## Update '1.2.8'
-Add function Get-GOAuthIdToken -- Function returns a Google ID Toekn for a user for a given Client ID
+Add function Get-GOAuthIdToken -- Function returns a Google ID Token for a user for a given Client ID
 
 ## Update '1.2.7'
 Expand Get-GFilePermissions to get more details and get specific permissions if specified

--- a/UMN-Google.psd1
+++ b/UMN-Google.psd1
@@ -28,7 +28,7 @@
 RootModule = 'UMN-Google.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.2.8'
+ModuleVersion = '1.2.9'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -123,7 +123,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-         ReleaseNotes = 'Ad function Get-GOAuthIdToken'
+         ReleaseNotes = 'Modify Get-GSheetData to set all empty properties of the returned object to an empty string instead of $null.'
 
     } # End of PSData hashtable
 

--- a/UMN-Google.psm1
+++ b/UMN-Google.psm1
@@ -968,7 +968,11 @@ function Update-GFilePermissions
                 foreach ($Column in 0..($Columns-1)) {
                     if ($sheet[0][$Column].Length -gt 0) {
                         $Name = $Header[$Column]
-                        $h.$Name = $Sheet[$Row][$Column]
+                        if ($sheet[$row].count -gt ($column)) {
+                            $h.$Name = $Sheet[$Row][$Column]
+                        } else {
+                            $h.$Name = ""
+                        }
                     }
                 }
                 [PSCustomObject]$h


### PR DESCRIPTION
this will set all empty data to be an empty string instead of some being $null, we could go the other way but it would break all our code and probably the code of anyone else using this, I think having everything be an empy string instead of $null is going to be safer